### PR TITLE
Fix database tables creation in main.py

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -11,3 +11,6 @@ SQLModel.metadata.create_all(engine)
 def get_session():
     with Session(engine) as session:
         yield session
+
+def create_all():
+    SQLModel.metadata.create_all(engine)

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,9 +6,11 @@ from fastapi import FastAPI, HTTPException
 from backend.middlewares import init_middlewares
 from backend.schemas import UserOverview, User, UserProfile, Role, UserActivity, CommunicationTools, UserSubscription, \
     DataExport, UserCompliance, UserCustomization, UserEngagement, UserImportExport, Integration, SystemHealth
+from backend.database import create_all
 
 app = FastAPI()
 
+create_all()
 init_middlewares(app)
 
 # Define API endpoints


### PR DESCRIPTION
Add function to create database tables when running `main.py`.

* **backend/database.py**
  - Add `create_all` function to call `SQLModel.metadata.create_all(engine)`.

* **backend/main.py**
  - Import `create_all` from `backend/database.py`.
  - Call `create_all` before starting the FastAPI app.

